### PR TITLE
Update elb_target_groups.py

### DIFF
--- a/cloud/amazon/elb_target_group.py
+++ b/cloud/amazon/elb_target_group.py
@@ -241,6 +241,34 @@ def wait_for_status(connection, module, target_group_arn, targets, status):
     return status_achieved, result
 
 
+def update_tg_attributes(connection, module, tg):
+    """Update ELB attributes. Return true if changed, else false"""
+
+    attribute_changed = False
+    update_required = False
+    params = dict()
+
+    tg_attributes = connection.describe_target_group_attributes(TargetGroupArn=tg['TargetGroupArn'])
+
+    if module.params.get("attributes"):
+        params['Attributes'] = module.params.get("attributes")
+
+        for new_attribute in params['Attributes']:
+            for current_attribute in tg_attributes['Attributes']:
+                if new_attribute['Key'] == current_attribute['Key']:
+                    if new_attribute['Value'] != current_attribute['Value']:
+                        update_required = True
+
+    if update_required: 
+        attribute_changed = True
+        try:
+            connection.modify_target_group_attributes(TargetGroupArn=tg['TargetGroupArn'], Attributes=params['Attributes'])
+        except (ClientError, NoCredentialsError) as e:
+                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+    
+    return attribute_changed
+
+
 def create_or_update_target_group(connection, module):
 
     changed = False
@@ -411,6 +439,13 @@ def create_or_update_target_group(connection, module):
                     if not status_achieved:
                         module.fail_json(msg='Error waiting for target deregistration - please check the AWS console')
 
+
+        if module.params.get("attributes"):
+            # Now set tg attributes. 
+            attribute_changed = update_tg_attributes(connection, module, tg)
+            if attribute_changed:
+                changed = True
+
     else:
         try:
             connection.create_target_group(**params)
@@ -431,6 +466,12 @@ def create_or_update_target_group(connection, module):
                 status_achieved, registered_instances = wait_for_status(connection, module, tg['TargetGroupArn'], params['Targets'], 'healthy')
                 if not status_achieved:
                     module.fail_json(msg='Error waiting for target registration - please check the AWS console')
+
+        if module.params.get("attributes"):
+            # Now set tg attributes
+            attribute_changed = update_tg_attributes(connection, module, tg)
+            if attribute_changed:
+                changed = True
 
     # Get the target group again
     tg = get_target_group(connection, module)
@@ -472,6 +513,7 @@ def main():
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             successful_response_codes=dict(required=False, default='200', type='str'),
             targets=dict(required=False, type='list'),
+            attributes=dict(required=False, type='list'),
             wait_timeout=dict(required=False, type='int'),
             wait=dict(required=False, type='bool')
         )


### PR DESCRIPTION
Added support for attributes for target groups. For example, you can now set cookie stickiness settings on a target group. 

Example:

```
  - elb_target_group:
      region: ap-southeast-2
      profile: auto_general_dev
      name: test
      protocol: https
      port: 444
      vpc_id: vpc-aad12345
      health_check_path: /
      successful_response_codes: "200,250-260"
      attributes:
        - Key: stickiness.enabled
          Value: 'true'
        - Key: stickiness.type
          Value: 'lb_cookie'
        - Key: stickiness.lb_cookie.duration_seconds
          Value: '300'                    
      state: present
      wait: False
```